### PR TITLE
Fix authentication when using repository parameters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,7 @@ poetry config pypi-token.pypi $3
 if [ -z $4 ] || [ -z $5 ]; then
   poetry publish
 else
+  poetry config pypi-token.$4 $3
   poetry config repositories.$4 $5
   poetry publish --repository $4
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,8 +15,8 @@ else
 fi
 
 poetry build
-poetry config pypi-token.pypi $3
 if [ -z $4 ] || [ -z $5 ]; then
+  poetry config pypi-token.pypi $3
   poetry publish
 else
   poetry config pypi-token.$4 $3


### PR DESCRIPTION
## Problem

https://github.com/scanapi/scanapi/issues/249

Authentication is not working when using repository parameters

```
Building scanapi (1.0.5)
 - Building sdist
 - Built scanapi-1.0.5.tar.gz
 - Building wheel
 - Built scanapi-1.0.5-py3-none-any.whl
No suitable keyring backends were found
Using a plaintext file to store and retrieve credentials
Publishing scanapi (1.0.5) to testpypi
No suitable keyring backends were found
Using a plaintext file to store and retrieve credentials

[RuntimeError]
Aborted
Username: 
```

## Solution

Use `repository_name` on authentication

https://github.com/scanapi/scanapi/pull/252
https://github.com/scanapi/scanapi/pull/252/checks?check_run_id=986697824
https://test.pypi.org/project/scanapi/