### PR TITLE
add optional argument to install project without developer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ to publish to.
     build_format: 'sdist'
     repository_name: 'testpypi'
     repository_url: 'https://test.pypi.org/legacy/'
+    ignore_dev_requirements: "yes"
 ```
 
 ## Example workflow

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The name of a repository where the package will be uploaded. Necessary if you'd 
 
 The URL where the package will be uploaded. Necessary if you'd like to upload to test PyPi or a private wheels repo. Uploads to official PyPi if not informed.
 
+### `ignore_dev_requirements`
+
+This will instruct poetry **not** to install any developer requirements. this may lead to an overall quicker experience.
+
 ## Example usage
 
 The following will build and publish the pyhon package using the last version of python and poetry. Specify the python package version and dependencies in `pyproject.toml` in the root directory of your project.

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: "URL where the package will be uploaded"
     required: false
   ignore_dev_requirements:
-    description: "Install without developer-requirements."
+    description: "Install project without developer requirements."
     required: false
 runs:
   using: "docker"

--- a/action.yml
+++ b/action.yml
@@ -1,33 +1,36 @@
-name: 'Publish python poetry package'
-author: '@JRubics'
-description: 'An action to build and publish python package to https://pypi.org/ using poetry https://github.com/sdispater/poetry'
+name: "Publish python poetry package"
+author: "@JRubics"
+description: "An action to build and publish python package to https://pypi.org/ using poetry https://github.com/sdispater/poetry"
 branding:
-  icon: 'upload-cloud'
-  color: 'gray-dark'
+  icon: "upload-cloud"
+  color: "gray-dark"
 inputs:
   python_version:
-    description: 'The version of python to install'
+    description: "The version of python to install"
     required: true
-    default: 'latest'
+    default: "latest"
   poetry_version:
-    description: 'The version of poetry to install'
+    description: "The version of poetry to install"
     required: true
-    default: 'latest'
+    default: "latest"
   pypi_token:
-    description: 'API token to authenticate when uploading package to PyPI (https://pypi.org/manage/account/)'
+    description: "API token to authenticate when uploading package to PyPI (https://pypi.org/manage/account/)"
     required: true
   build_format:
     description: 'The build format to be used, either "sdist" or "wheel"'
     required: false
   repository_name:
-    description: 'Name of a repository where we will upload the package'
+    description: "Name of a repository where we will upload the package"
     required: false
   repository_url:
-    description: 'URL where the package will be uploaded'
+    description: "URL where the package will be uploaded"
+    required: false
+  ignore_dev_requirements:
+    description: "Install without developer-requirements."
     required: false
 runs:
-  using: 'docker'
-  image: 'docker://jrubics/poetry-publish:v1.6'
+  using: "docker"
+  image: "docker://jrubics/poetry-publish:v1.6"
   args:
     - ${{ inputs.python_version }}
     - ${{ inputs.poetry_version }}
@@ -35,3 +38,4 @@ runs:
     - ${{ inputs.repository_name}}
     - ${{ inputs.repository_url }}
     - ${{ inputs.build_format }}
+    - ${{ inputs.ignore_dev_requirements }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
   pip install poetry
 fi
 
-if [ -z "$7" ]; then
+if [ -z $7 ]; then
     poetry install
 else
   poetry install --no-dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,11 @@ else
   pip install poetry
 fi
 
-poetry install
+if [ -z "$7" ]; then
+    poetry install
+else
+  poetry install --no-dev
+fi
 
 if [ -z $6 ]; then
   poetry build


### PR DESCRIPTION
one of my projects has a large number of developer dependencies that aren't required when building. I thought this optional arugment may cut down the time it takes to install, build + publish


also my IDE appears to formatted the ``actions.yml`` file and replaced single quotes with double quotes.. I'm pretty sure it's still valid but I can change them back again if needed.