### PR TITLE
Allow poetry pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The URL where the package will be uploaded. Necessary if you'd like to upload to
 
 This will instruct poetry **not** to install any developer requirements. this may lead to an overall quicker experience.
 
+### `allow_poetry_pre_release`
+
+Allow poetry pre-release versions to be installed.
+
 ## Example usage
 
 The following will build and publish the pyhon package using the last version of python and poetry. Specify the python package version and dependencies in `pyproject.toml` in the root directory of your project.

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   ignore_dev_requirements:
     description: "Install project without developer requirements."
     required: false
+  allow_poetry_pre_release:
+    description: "Allow usage of poetry pre-release and development versions"
+    required: false
 runs:
   using: "docker"
   image: "docker://jrubics/poetry-publish:v1.7"
@@ -39,3 +42,4 @@ runs:
     - ${{ inputs.repository_url }}
     - ${{ inputs.build_format }}
     - ${{ inputs.ignore_dev_requirements }}
+    - ${{ inputs.allow_poetry_pre_release }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,16 @@ if [ $1 != 'latest' ]; then
   pyenv rehash
 fi
 
-if [ $2 != 'latest' ]; then
-  pip install poetry$2
+if [ -z $8 ]; then
+  pre=""
 else
-  pip install poetry
+  pre="--pre"
+fi
+
+if [ $2 != 'latest' ]; then
+  pip install poetry$2 $pre
+else
+  pip install poetry $pre
 fi
 
 if [ -z $7 ]; then


### PR DESCRIPTION
I'm trying to use poetry plugins but that requires 1.2.0a1 but being a pre-release pip cannot install it by default. I made this an opt-in feature.