### PR TITLE
Fix private package server code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following will build and publish the python package to the PyPI using the la
 
 ```yaml
 - name: Build and publish to pypi
-  uses: JRubics/poetry-publish@v1.8
+  uses: JRubics/poetry-publish@v1.9
   with:
     pypi_token: ${{ secrets.PYPI_TOKEN }}
 ```
@@ -63,7 +63,7 @@ Python and poetry versions can be specified in inputs as well as the build_forma
 
 ```yaml
 - name: Build and publish to pypi
-  uses: JRubics/poetry-publish@v1.8
+  uses: JRubics/poetry-publish@v1.9
   with:
     python_version: "3.7.1"
     poetry_version: "==1.0.5" # (PIP version specifier syntax)
@@ -77,7 +77,7 @@ Repository can be changed to TestPyPI or a private wheels repo by specifying rep
 
 ```yaml
 - name: Build and publish to pypi
-  uses: JRubics/poetry-publish@v1.8
+  uses: JRubics/poetry-publish@v1.9
   with:
     pypi_token: ${{ secrets.PYPI_TOKEN }}
     repository_name: "testpypi"
@@ -87,8 +87,8 @@ Repository can be changed to TestPyPI or a private wheels repo by specifying rep
 Repository authentication can be cahnged to http-basic authentification by specifying repository_username and repository_password instead of pypi_token.
 
 ```yaml
-- name: Build and publish to pypi
-  uses: JRubics/poetry-publish@v1.8
+- name: Build and publish to private Python package repository
+  uses: JRubics/poetry-publish@v1.9
   with:
     repository_name: "foo"
     repository_url: "https://foo.bar/simple/"
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.8
+        uses: JRubics/poetry-publish@v1.9
         with:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ branding:
 inputs:
   python_version:
     description: "The version of python to install"
-    required: true
+    required: false
     default: "latest"
   poetry_version:
     description: "The version of poetry to install"
-    required: true
+    required: false
     default: "latest"
   pypi_token:
     description: "API token to authenticate when uploading package to PyPI (https://pypi.org/manage/account/) or TestPyPI (https://test.pypi.org/manage/account/)"


### PR DESCRIPTION
All code samples listed the previous version of this action, which did not support private packages with basic HTTP auth. That made for a confusing experience where I used the code sample but it did not work, so I updated them.

This also changes python version and poetry version fields to be marked as optional, as VSCode complains about them being missing, but they have default values.