### PR TITLE
Add "extra_build_dependency_packages" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ This will instruct poetry **not** to install any developer requirements. this ma
 
 Allow poetry pre-release versions to be installed.
 
+### `extra_build_dependency_packages`
+
+An optional space-separated list of debian packages to be installed before building the package
+
 ## Example usage
 
 The following will build and publish the python package to the PyPI using the last version of python and poetry. Specify the python package version and dependencies in `pyproject.toml` in the root directory of your project.

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://jrubics/poetry-publish:v1.9"
+  image: "docker://alecksgates/poetry-publish:v1.10"
   args:
     - ${{ inputs.python_version }}
     - ${{ inputs.poetry_version }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "Publish python poetry package"
-author: "@JRubics"
+name: "Publish python poetry package - agates"
+author: "@agates"
 description: "An action to build and publish python package to https://pypi.org/ using poetry https://github.com/sdispater/poetry"
 branding:
   icon: "upload-cloud"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "Publish python poetry package - agates"
-author: "@agates"
+name: "Publish python poetry package"
+author: "@JRubics"
 description: "An action to build and publish python package to https://pypi.org/ using poetry https://github.com/sdispater/poetry"
 branding:
   icon: "upload-cloud"
@@ -42,7 +42,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://alecksgates/poetry-publish:v1.10"
+  image: "docker://jrubics/poetry-publish:v1.10"
   args:
     - ${{ inputs.python_version }}
     - ${{ inputs.poetry_version }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   allow_poetry_pre_release:
     description: "Allow usage of poetry pre-release and development versions"
     required: false
+  extra_build_dependency_packages:
+    description: "An optional space-separated list of debian packages to be installed before building the package"
+    required: false
 runs:
   using: "docker"
   image: "docker://jrubics/poetry-publish:v1.9"
@@ -51,3 +54,4 @@ runs:
     - ${{ inputs.allow_poetry_pre_release }}
     - ${{ inputs.repository_username }}
     - ${{ inputs.repository_password }}
+    - ${{ inputs.extra_build_dependency_packages }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z $11 ]; then
+if [ -n $11 ]; then
   apt-get update
   apt-get -y upgrade
   apt-get -y install --no-install-recommends $11

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -n ${11} ]; then
+if [ -n "${11}" ]; then
   apt-get update
   apt-get -y upgrade
   apt-get -y install --no-install-recommends ${11}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ -z $11 ]; then
+  apt-get update
+  apt-get -y upgrade
+  apt-get -y install --no-install-recommends $11
+fi
+
 if [ $1 != 'latest' ]; then
   pyenv latest install $1
   pyenv latest global $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-if [ -n $11 ]; then
+if [ -n ${11} ]; then
   apt-get update
   apt-get -y upgrade
-  apt-get -y install --no-install-recommends $11
+  apt-get -y install --no-install-recommends ${11}
 fi
 
 if [ $1 != 'latest' ]; then


### PR DESCRIPTION
This input allows for extra debian packages to be installed before building the python package.  This is particularly useful for packages that do not need to be included in the base image for this action.

Tested it with this release:
https://github.com/Podcastindex-org/podping-hivewriter/runs/4915166355?check_suite_focus=true#step:4:9