### PR TITLE
Add support for Poetry Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Allow poetry pre-release versions to be installed.
 
 An optional space-separated list of debian packages to be installed before building the package
 
+### `plugins`
+
+An optional space-separated list of poetry plugins to be installed before building the package
+
+
 ## Example usage
 
 The following will build and publish the python package to the PyPI using the last version of python and poetry. Specify the python package version and dependencies in `pyproject.toml` in the root directory of your project.

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   extra_build_dependency_packages:
     description: "An optional space-separated list of debian packages to be installed before building the package"
     required: false
+  plugins:
+    description: "An optional space-separated list of poetry plugins to be installed before building the package"
+    required: false
 runs:
   using: "docker"
   image: "docker://jrubics/poetry-publish:v1.10"
@@ -55,3 +58,4 @@ runs:
     - ${{ inputs.repository_username }}
     - ${{ inputs.repository_password }}
     - ${{ inputs.extra_build_dependency_packages }}
+    - ${{ inputs.plugins }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,10 @@ else
   pip install poetry $pre
 fi
 
+if [ -n "${12}" ]; then
+  poetry plugin add ${12}
+fi
+
 if [ -z $7 ]; then
   poetry install
 else


### PR DESCRIPTION
Installs optional poetry plugins before installing the project.

Example use-case:

```
          plugins: "poetry-dynamic-versioning-plugin"
```